### PR TITLE
Use native `JSON.parse`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   },
   "dependencies": {
     "js-base64": "^2.4.3",
-    "json-stable-stringify": "^1.0.1",
-    "parse-json": "^4.0.0"
+    "json-stable-stringify": "^1.0.1"
   },
   "description": "Deterministically convert an object to a Base64 string and back.",
   "devDependencies": {

--- a/src/decode.js
+++ b/src/decode.js
@@ -1,10 +1,9 @@
 // @flow
 import assert from 'assert';
 import {Base64} from 'js-base64';
-import parseJson from 'parse-json';
 
 export default function decode(text: string): any {
   assert(typeof text === 'string', '"text" must be a string.');
   const json = Base64.decode(text);
-  return parseJson(json);
+  return JSON.parse(json);
 }


### PR DESCRIPTION
I realized better error messages aren't helpful when they're pointed to translated goop.